### PR TITLE
feature: camb-convolution-backward-return-empty-tensor-if-needed

### DIFF
--- a/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -455,6 +455,15 @@
     ::diopiSize_t output_paddingDiopiSize;
   custom_code_before_call_diopi: |
     ::diopiSize_t* bias_sizes_ptr = output_mask[2] ? &bias_sizesDiopiSize : nullptr;
+  custom_code_before_return: |
+    at::Tensor grad_input_empty;
+    at::Tensor grad_weight_empty;
+    if (!output_mask[0]) {
+        grad_input = grad_input_empty;
+    }
+    if (!output_mask[1]) {
+        grad_weight = grad_weight_empty;
+    }
   interface: diopiConvolution2dBackward(ctx, grad_input, grad_weight, grad_bias, grad_output, input, weight, bias_sizes_ptr, stride, padding, dilation, transposed, output_paddingDiopiSize, groups);
 
 - schema: "convolution_backward(Tensor grad_output, Tensor input, Tensor weight, int[] bias_sizes, int[] stride, int[] padding, int[] dilation, bool transposed, int[] output_padding, int groups, bool[3] output_mask) -> (Tensor grad_input, Tensor grad_weight, Tensor grad_bias)"


### PR DESCRIPTION
camb convolution backward return empty tensor if needed