### PR TITLE
yb/fix build error of constructing diopiSize_t

### DIFF
--- a/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -455,8 +455,8 @@ def create_int_array_process_code(int_array_list):
     for int_array in int_array_list:
         code += f"std::vector<int64_t> {int_array}Vector({int_array}.size());\n"
         code += f"std::transform({int_array}.cbegin(), {int_array}.cend(), {int_array}Vector.begin(), symIntToInt);\n"
-        code += f"::diopiSize_t {int_array}DiopiSize({int_array}Vector.data(), {int_array}Vector.size());\n"
-    return code;
+        code += f"::diopiSize_t {int_array}DiopiSize{{{int_array}Vector.data(), static_cast<int64_t>({int_array}Vector.size())}};\n"
+    return code
 
 def create_autograd_function_name(op_name):
     op_name = 'Dipu' + op_name[0].upper() + op_name[1:]

--- a/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -455,7 +455,7 @@
     if (output_mask[2]) {
         grad_bias = at::empty(bias_sizes, grad_output.options());
     }
-    ::diopiSize_t output_paddingDiopiSize;
+    ::diopiSize_t output_paddingDiopiSize{nullptr, 0};
   custom_code_before_call_diopi: |
     ::diopiSize_t* bias_sizes_ptr = output_mask[2] ? &bias_sizesDiopiSize : nullptr;
   custom_code_before_return: |
@@ -486,7 +486,7 @@
     if (output_mask[2]) {
         grad_bias = at::empty(bias_sizes, grad_output.options());
     }
-    ::diopiSize_t output_paddingDiopiSize;
+    ::diopiSize_t output_paddingDiopiSize{nullptr, 0};
   custom_code_before_call_diopi: |
     ::diopiSize_t* bias_sizes_ptr = output_mask[2] ? &bias_sizesDiopiSize : nullptr;
   interface: diopiConvolution2dBackward(ctx, grad_input, grad_weight, grad_bias, grad_output, input, weight, bias_sizes_ptr, stride, padding, dilation, transposed, output_paddingDiopiSize, groups);

--- a/scripts/ci/camb/ci_camb_env.sh
+++ b/scripts/ci/camb/ci_camb_env.sh
@@ -26,7 +26,7 @@ export DIPU_PATH=${DIPU_ROOT}
 
 #export MLU_INVOKE_BLOCKING=1
 
-export DIPU_FORCE_FALLBACK_OPS_LIST=mul.Scalar,mul_.Scalar,mul.Scalar_out,mul_.Tensor,mul.out,add_out,_index_put_impl_,_unique2,col2im
+export DIPU_FORCE_FALLBACK_OPS_LIST=mul.Scalar,mul_.Scalar,mul.Scalar_out,mul_.Tensor,mul.out,add_out,_index_put_impl_,_unique2,col2im,normal_,random_.from,uniform_,add.out
 
 #export DIPU_DEBUG_ALLOCATOR=15
 export DIPU_DEVICE_MEMCACHING_ALGORITHM=BS

--- a/torch_dipu/csrc_dipu/diopirt/diopi_helper.cpp
+++ b/torch_dipu/csrc_dipu/diopirt/diopi_helper.cpp
@@ -175,7 +175,7 @@ c10::DeviceType toATenDevice(::diopiDevice_t device) {
 }
 
 ::diopiSize_t toDiopiSize(const at::OptionalIntArrayRef& input) {
-    ::diopiSize_t diopi_size;
+    ::diopiSize_t diopi_size{nullptr, 0};
     if (input.has_value()) {
         diopi_size.data = input.value().data();
         diopi_size.len = input.value().size();
@@ -184,7 +184,7 @@ c10::DeviceType toATenDevice(::diopiDevice_t device) {
 }
 
 ::diopiSize_t toDiopiSize(at::IntArrayRef input) {
-    ::diopiSize_t diopi_size;
+    ::diopiSize_t diopi_size{nullptr, 0};
     diopi_size.data = input.data();
     diopi_size.len = input.size();
     return diopi_size;

--- a/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
+++ b/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
@@ -30,13 +30,13 @@ DIOPI_RT_API diopiError_t diopiGetTensorDataConst(diopiConstTensorHandle_t pth, 
 
 DIOPI_RT_API diopiError_t diopiGetTensorShape(diopiConstTensorHandle_t pth, diopiSize_t* size) {
     const at::Tensor* ptr = reinterpret_cast<const at::Tensor*>(pth);
-    *size = diopiSize_t(ptr->sizes().data(), ptr->dim());
+    *size = diopiSize_t{ptr->sizes().data(), static_cast<int64_t>(ptr->dim())};
     return diopiSuccess;
 }
 
 DIOPI_RT_API diopiError_t diopiGetTensorStride(diopiConstTensorHandle_t pth, diopiSize_t* stride) {
     const at::Tensor* ptr = reinterpret_cast<const at::Tensor*>(pth);
-    *stride = diopiSize_t(ptr->strides().data(), ptr->dim());
+    *stride = diopiSize_t{ptr->strides().data(), static_cast<int64_t>(ptr->dim())};
     return diopiSuccess;
 }
 
@@ -103,7 +103,7 @@ DIOPI_RT_API diopiError_t diopiRequireTensor(
 DIOPI_RT_API diopiError_t diopiRequireBuffer(
     diopiContextHandle_t ctx, diopiTensorHandle_t* tensor,
     int64_t num_bytes, diopiDevice_t device) {
-    diopiSize_t size(&num_bytes, 1);
+    diopiSize_t size{&num_bytes, 1};
     return diopiRequireTensor(ctx, tensor, &size, nullptr, diopi_dtype_int8, device);
 }
 


### PR DESCRIPTION
* fix build error when using the new diopi, where the constructor of diopiSize_t is deleted.
* Add 4 operators (normal_, random_.from, uniform_, add.out) to fallback to CPU