### PR TITLE
fix a bug of setup.py when torch can't be imported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ import re
 import shutil
 import subprocess
 import sys
-import traceback
 import platform
 
 import distutils.ccompiler
@@ -66,13 +65,8 @@ def get_build_type():
     return build_type
 
 def get_pytorch_dir():
-    try:
-        import torch
-        return os.path.dirname(os.path.abspath(torch.__file__))
-    except Exception:
-        _, _, exc_traceback = sys.exc_info()
-        frame_summary = traceback.extract_tb(exc_traceback)[-1]
-        return os.path.dirname(frame_summary.filename)
+    import torch
+    return os.path.dirname(os.path.abspath(torch.__file__))
 
 class CPPLibBuild(build_clib, object):
     def run(self):


### PR DESCRIPTION
setup.py里在import不到torch的时候有一个奇怪的try except（我猜可能是为了处理这里的报错 https://github.com/pytorch/pytorch/blob/v2.0.0/torch/__init__.py#L443 ），但是问题是如果环境里就是import不到torch的话就会导致拿到的include_dirs有问题，然后会在编译extension的时候报找不到头文件，比较难以发现问题的原因。除了去掉try except这里也可以考虑改成except ImportError

get_pytorch_dir函数看起来是从https://github.com/Ascend/pytorch/blob/d6623f2f5b9f592c6a2665aec840231b08e7e5be/setup.py#L95 借鉴的