### PR TITLE
fix op_capture bug

### DIFF
--- a/scripts/op_capture/op_capture.py
+++ b/scripts/op_capture/op_capture.py
@@ -20,7 +20,7 @@ def parase_args():
     return args
 
 def get_all_op_from_train_log(log_content):
-    ops = re.findall('--\[.*\]:[ \w\d_]+\s[\t\w\d_\t: \.,\[\]\n]+', log_content)
+    ops = re.findall('(?:--\[.*\]: *[\w\d_]+ *)\s(?:[\t ]+[:\w\d_\.]+:.*\s)*', log_content)
     return ops
 
 def extract_op_arg(op):


### PR DESCRIPTION
1. Fix the bug that the data captured when there are floating-point numbers represented by scientific notation in the parameter is wrong
[dipu_ops.csv](https://github.com/DeepLink-org/DIPU/files/12513880/dipu_ops.csv)
