### PR TITLE
Change the is_cuda method to property to imitate native pytorch behavior

### DIFF
--- a/torch_dipu/__init__.py
+++ b/torch_dipu/__init__.py
@@ -24,9 +24,6 @@ from .dipu.dataloader import apply_dataloader_patch
 from .dipu.optim import apply_optim_patch
 from .dipu.generator import apply_generator_patch
 
-
-
-
 # mock device functions in generated/python_variable_methods.cpp
 def apply_tensor_method_patch():
     torch.Tensor.to = GetDeviceProxy(torch.Tensor.to)

--- a/torch_dipu/__init__.py
+++ b/torch_dipu/__init__.py
@@ -24,6 +24,9 @@ from .dipu.dataloader import apply_dataloader_patch
 from .dipu.optim import apply_optim_patch
 from .dipu.generator import apply_generator_patch
 
+
+
+
 # mock device functions in generated/python_variable_methods.cpp
 def apply_tensor_method_patch():
     torch.Tensor.to = GetDeviceProxy(torch.Tensor.to)
@@ -41,7 +44,7 @@ def apply_tensor_method_patch():
     torch.Tensor.new =  GetDeviceProxy(torch.Tensor.new,  pos = -1)
 
     torch.Tensor.dipu = GetDeviceProxy(_C.dipu)
-    torch.Tensor.is_dipu = GetDeviceProxy(_C.is_dipu)
+    torch.Tensor.is_dipu = property(GetDeviceProxy(_C.is_dipu))
     if mockcuda:
         torch.Tensor.cuda = torch.Tensor.dipu
         torch.Tensor.is_cuda = torch.Tensor.is_dipu


### PR DESCRIPTION
The calling method of is_cuda in pytorch is a.is_cuda.
dipu should be consistent with this usage