### PR TITLE
add stack info

### DIFF
--- a/dipu/torch_dipu/profiler/profiler.py
+++ b/dipu/torch_dipu/profiler/profiler.py
@@ -96,6 +96,11 @@ class dipu_profiler(object):
                     for i in evt.input_shapes:
                         if len(i) != 0:
                             input_shape.append(i)
+                stack = []
+                if evt.stack is not None:
+                    for i in evt.stack:
+                        if len(i)!=0:
+                            stack.append(i)
                 f.write(
                     '{"name": "%s", '
                     '"ph": "X", '
@@ -103,7 +108,7 @@ class dipu_profiler(object):
                     '"dur": %s, '
                     '"tid": %s, '
                     '"pid": "CPU functions", '
-                    '"args": {%s}}, '
+                    '"args": {%s, %s}}, '
                     % (
                         evt.trace_name,
                         evt.time_range.start,
@@ -112,7 +117,7 @@ class dipu_profiler(object):
                         if not evt.is_remote
                         else f'" node_id:{evt.node_id}, thread_id:{evt.thread} "',
                         '"input shape": ' + ('"%s"' % str(input_shape)),
-
+                        '"stack": '+ ('"%s"' % str(stack)),
                     )
                 )
                 for k in evt.kernels:


### PR DESCRIPTION
从原生的torch profiler 获取stack信息
开启方法如下：
with profile(record_shapes=True, with_stack=True,  experimental_config=torch._C._profiler._ExperimentalConfig(verbose=True)) as prof:
    ’‘’需要记录的操作‘’‘
print(prof.key_averages(group_by_stack_n=5))
prof.export_chrome_trace('result_pytorch_dipu_with_stack.json')

获得结果如下：

![image](https://github.com/DeepLink-org/DIPU/assets/77915156/2799b60b-3d07-4c4c-a01b-5a8c744cd5ae)
