### PR TITLE
(lljbash) CMake 优化

### DIFF
--- a/dipu/CMakeLists.txt
+++ b/dipu/CMakeLists.txt
@@ -105,16 +105,16 @@ link_directories(${TORCH_LIBRARY_DIR})
 list(APPEND TORCH_INCLUDE_DIRS ${PYTORCH_DIR}/torch/include/
     ${PYTORCH_DIR}/torch/include/torch/csrc/api/include/
 )
-include_directories(${TORCH_INCLUDE_DIRS})
+include_directories(SYSTEM ${TORCH_INCLUDE_DIRS})
 message(STATUS "Torch TORCH_INCLUDE_DIRS: ${TORCH_INCLUDE_DIRS}")
 
 # diopi
 set(WITH_DIOPI "${CMAKE_SOURCE_DIR}/third_party/DIOPI")
 add_library(diopi_impl SHARED IMPORTED)
 set_target_properties(diopi_impl PROPERTIES
-    IMPORTED_LOCATION "${WITH_DIOPI}/impl/lib/libdiopi_impl.so"
-    INTERFACE_INCLUDE_DIRECTORIES "${WITH_DIOPI}/proto/include"
-    INTERFACE_COMPILE_DEFINITIONS DIOPI_ATTR_WEAK)
+    IMPORTED_LOCATION "${WITH_DIOPI}/impl/lib/libdiopi_impl.so")
+target_include_directories(diopi_impl INTERFACE "${WITH_DIOPI}/proto/include")
+target_compile_definitions(diopi_impl INTERFACE DIOPI_ATTR_WEAK)
 
 if (LIBS)
   add_subdirectory(torch_dipu/csrc_dipu)

--- a/dipu/CMakeLists.txt
+++ b/dipu/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 3.10)
 project(TorchDIPU)
 
@@ -110,9 +109,12 @@ include_directories(${TORCH_INCLUDE_DIRS})
 message(STATUS "Torch TORCH_INCLUDE_DIRS: ${TORCH_INCLUDE_DIRS}")
 
 # diopi
-set(DIOPI_PROTO_PATH "${PROJECT_SOURCE_DIR}/third_party/DIOPI/proto")
-include_directories(${DIOPI_PROTO_PATH}/include)
-add_definitions(-DDIOPI_ATTR_WEAK)
+set(WITH_DIOPI "${CMAKE_SOURCE_DIR}/third_party/DIOPI")
+add_library(diopi_impl SHARED IMPORTED)
+set_target_properties(diopi_impl PROPERTIES
+    IMPORTED_LOCATION "${WITH_DIOPI}/impl/lib/libdiopi_impl.so"
+    INTERFACE_INCLUDE_DIRECTORIES "${WITH_DIOPI}/proto/include"
+    INTERFACE_COMPILE_DEFINITIONS DIOPI_ATTR_WEAK)
 
 if (LIBS)
   add_subdirectory(torch_dipu/csrc_dipu)

--- a/dipu/CMakeLists.txt
+++ b/dipu/CMakeLists.txt
@@ -109,7 +109,8 @@ if(ENABLE_COVERAGE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
 
-# findTorch encounter some error, need check
+# TODO(lljbash): findTorch encounter some error, need check
+# ~~~
 # set(Torch_DIR ${PYTORCH_DIR}/share/cmake/Torch)
 # find_package(Torch REQUIRED)
 # if (NOT Torch_FOUND)
@@ -120,6 +121,7 @@ endif()
 #     message(STATUS "Found Torch Version: ${Torch_VERSION}")
 #     message(STATUS "Torch TORCH_LIBRARIES: ${TORCH_LIBRARIES}")
 # endif()
+# ~~~
 
 set(TORCH_LIBRARY_DIR "${PYTORCH_DIR}/torch/lib")
 link_directories(${TORCH_LIBRARY_DIR})

--- a/dipu/CMakeLists.txt
+++ b/dipu/CMakeLists.txt
@@ -2,14 +2,16 @@ cmake_minimum_required(VERSION 3.10)
 project(TorchDIPU)
 
 option(TESTS "Whether to build unit tests" OFF)
-option(LIBS  "Whether to build dipu lib, default on" ON)
+option(LIBS "Whether to build dipu lib, default on" ON)
 
 # use gcover
-OPTION (ENABLE_COVERAGE "Use gcov" OFF)
-MESSAGE(STATUS ENABLE_COVERAGE=${ENABLE_COVERAGE})
+option(ENABLE_COVERAGE "Use gcov" OFF)
+message(STATUS ENABLE_COVERAGE=${ENABLE_COVERAGE})
 
 # device related
-set(DEVICE "camb" CACHE STRING "device string, default camb")
+set(DEVICE
+    "camb"
+    CACHE STRING "device string, default camb")
 list(APPEND DEVICE_CAMB "CAMB" "camb")
 list(APPEND DEVICE_CUDA "CUDA" "cuda")
 list(APPEND DEVICE_ASCEND "ASCEND" "ascend")
@@ -17,39 +19,59 @@ list(APPEND DEVICE_TOPSRIDER "TOPS" "tops" "TOPSRIDER" "topsrider")
 list(APPEND DEVICE_SUPA "SUPA" "supa")
 list(APPEND DEVICE_DROPLET "DROPLET" "droplet")
 
-execute_process(COMMAND git rev-parse --short HEAD OUTPUT_VARIABLE DIPU_GIT_HASH)
+execute_process(COMMAND git rev-parse --short HEAD
+                OUTPUT_VARIABLE DIPU_GIT_HASH)
 string(REGEX MATCH "[a-z0-9_]+" DIPU_GIT_HASH ${DIPU_GIT_HASH})
-execute_process(COMMAND  sh -c "git status --porcelain | egrep '^(M| M)' | wc -l" OUTPUT_VARIABLE DIPU_MODIFY_LEN)
-if (DIPU_MODIFY_LEN GREATER 0)
-    set(DIPU_GIT_HASH ${DIPU_GIT_HASH}-dirty)
+execute_process(COMMAND sh -c "git status --porcelain | egrep '^(M| M)' | wc -l"
+                OUTPUT_VARIABLE DIPU_MODIFY_LEN)
+if(DIPU_MODIFY_LEN GREATER 0)
+  set(DIPU_GIT_HASH ${DIPU_GIT_HASH}-dirty)
 endif()
 message(STATUS "DIPU_GIT_HASH: " ${DIPU_GIT_HASH})
 add_compile_options(-DDIPU_GIT_HASH="${DIPU_GIT_HASH}")
 
 # Automatically generate a list of supported diopi functions
-execute_process(COMMAND  sh -x -c "grep -Po 'diopi[a-zA-Z0-9]+(?=\\()' ${CMAKE_CURRENT_SOURCE_DIR}/scripts/autogen_diopi_wrapper/diopi_functions.yaml | sort -u > ${CMAKE_CURRENT_SOURCE_DIR}/SupportedDiopiFunctions.txt")
+execute_process(
+  COMMAND
+    sh -x -c
+    "grep -Po 'diopi[a-zA-Z0-9]+(?=\\()' ${CMAKE_CURRENT_SOURCE_DIR}/scripts/autogen_diopi_wrapper/diopi_functions.yaml | sort -u > ${CMAKE_CURRENT_SOURCE_DIR}/SupportedDiopiFunctions.txt"
+)
 
-execute_process(COMMAND sh -x -c "python -c 'import torch, builtins; print(next(item[-4:-2] for item in dir(builtins)      \
-        if \"__pybind11_internals_v4_gcc_libstdcpp_cxxabi10\" in item))'" OUTPUT_VARIABLE DIPU_ABI_V)
+execute_process(
+  COMMAND
+    sh -x -c
+    "python -c 'import torch, builtins; print(next(item[-4:-2] for item in dir(builtins)      \
+        if \"__pybind11_internals_v4_gcc_libstdcpp_cxxabi10\" in item))'"
+  OUTPUT_VARIABLE DIPU_ABI_V)
 add_definitions(-fabi-version=${DIPU_ABI_V})
 message(STATUS "DIPU_ABI_V: ${DIPU_ABI_V}")
 
-execute_process(COMMAND  sh -x -c "python -c 'import torch;print(1 if torch.compiled_with_cxx11_abi() else 0)'" OUTPUT_VARIABLE DIPU_COMPILED_WITH_CXX11_ABI)
-if (DIPU_COMPILED_WITH_CXX11_ABI GREATER 0)
-    set(DIPU_COMPILED_WITH_CXX11_ABI 1)
+execute_process(
+  COMMAND
+    sh -x -c
+    "python -c 'import torch;print(1 if torch.compiled_with_cxx11_abi() else 0)'"
+  OUTPUT_VARIABLE DIPU_COMPILED_WITH_CXX11_ABI)
+if(DIPU_COMPILED_WITH_CXX11_ABI GREATER 0)
+  set(DIPU_COMPILED_WITH_CXX11_ABI 1)
 else()
-    set(DIPU_COMPILED_WITH_CXX11_ABI 0)
+  set(DIPU_COMPILED_WITH_CXX11_ABI 0)
 endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=${DIPU_COMPILED_WITH_CXX11_ABI}")
+set(CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=${DIPU_COMPILED_WITH_CXX11_ABI}"
+)
 add_compile_options(-D_GLIBCXX_USE_CXX11_ABI=${DIPU_COMPILED_WITH_CXX11_ABI})
 message(STATUS "DIPU_COMPILED_WITH_CXX11_ABI:" ${DIPU_COMPILED_WITH_CXX11_ABI})
 
-execute_process(COMMAND  sh -c "dirname $(find  $(dirname $(which python))/../ -name Python.h)" OUTPUT_VARIABLE PYTHON_INCLUDE_DIR)
+execute_process(
+  COMMAND sh -c "dirname $(find  $(dirname $(which python))/../ -name Python.h)"
+  OUTPUT_VARIABLE PYTHON_INCLUDE_DIR)
 message(STATUS "PYTHON_INCLUDE_DIR: " ${PYTHON_INCLUDE_DIR})
 
-execute_process(COMMAND  sh -c "dirname $(python -c 'import torch;print(torch.__path__[0])')" OUTPUT_VARIABLE PYTORCH_DIR)
-string (REPLACE "\n" "" PYTORCH_DIR "${PYTORCH_DIR}")
-string (REPLACE "\r" "" PYTORCH_DIR "${PYTORCH_DIR}")
+execute_process(
+  COMMAND sh -c "dirname $(python -c 'import torch;print(torch.__path__[0])')"
+  OUTPUT_VARIABLE PYTORCH_DIR)
+string(REPLACE "\n" "" PYTORCH_DIR "${PYTORCH_DIR}")
+string(REPLACE "\r" "" PYTORCH_DIR "${PYTORCH_DIR}")
 message(STATUS "PYTORCH_DIR: " ${PYTORCH_DIR})
 
 # config
@@ -57,37 +79,37 @@ include(cmake/BaseFuncions.cmake)
 _set_cpp_flags()
 
 set(UsedVendor "")
-if (${DEVICE} IN_LIST DEVICE_CUDA)
-    set(USE_CUDA ON)
-    set(UsedVendor cuda)
-elseif (${DEVICE} IN_LIST DEVICE_CAMB)
-    set(USE_CAMB ON)
-    set(UsedVendor camb)
-elseif (${DEVICE} IN_LIST DEVICE_ASCEND)
-    set(USE_ASCEND ON)
-    set(UsedVendor ascend)
-elseif (${DEVICE} IN_LIST DEVICE_TOPSRIDER)
-    set(USE_TOPSRIDER ON)
-    set(UsedVendor topsrider)
-elseif (${DEVICE} IN_LIST DEVICE_SUPA)
-    set(USE_SUPA ON)
-    set(UsedVendor supa)
-elseif (${DEVICE} IN_LIST DEVICE_DROPLET)
-    set(USE_DROPLET ON)
-    set(UsedVendor droplet)
+if(${DEVICE} IN_LIST DEVICE_CUDA)
+  set(USE_CUDA ON)
+  set(UsedVendor cuda)
+elseif(${DEVICE} IN_LIST DEVICE_CAMB)
+  set(USE_CAMB ON)
+  set(UsedVendor camb)
+elseif(${DEVICE} IN_LIST DEVICE_ASCEND)
+  set(USE_ASCEND ON)
+  set(UsedVendor ascend)
+elseif(${DEVICE} IN_LIST DEVICE_TOPSRIDER)
+  set(USE_TOPSRIDER ON)
+  set(UsedVendor topsrider)
+elseif(${DEVICE} IN_LIST DEVICE_SUPA)
+  set(USE_SUPA ON)
+  set(UsedVendor supa)
+elseif(${DEVICE} IN_LIST DEVICE_DROPLET)
+  set(USE_DROPLET ON)
+  set(UsedVendor droplet)
 else()
-    message(FATAL_ERROR "No implementation module is compiled, cmake requires option -DDEVICE=CAMB or CUDA or ASCEND or SUPA")
+  message(
+    FATAL_ERROR
+      "No implementation module is compiled, cmake requires option -DDEVICE=CAMB or CUDA or ASCEND or SUPA"
+  )
 endif()
 
-
-
-if (ENABLE_COVERAGE)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
-    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
+if(ENABLE_COVERAGE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
 
-
-# findTorch encounter some error, need check。
+# findTorch encounter some error, need check
 # set(Torch_DIR ${PYTORCH_DIR}/share/cmake/Torch)
 # find_package(Torch REQUIRED)
 # if (NOT Torch_FOUND)
@@ -99,33 +121,26 @@ endif()
 #     message(STATUS "Torch TORCH_LIBRARIES: ${TORCH_LIBRARIES}")
 # endif()
 
-
 set(TORCH_LIBRARY_DIR "${PYTORCH_DIR}/torch/lib")
 link_directories(${TORCH_LIBRARY_DIR})
 list(APPEND TORCH_INCLUDE_DIRS ${PYTORCH_DIR}/torch/include/
-    ${PYTORCH_DIR}/torch/include/torch/csrc/api/include/
-)
+     ${PYTORCH_DIR}/torch/include/torch/csrc/api/include/)
 include_directories(SYSTEM ${TORCH_INCLUDE_DIRS})
 message(STATUS "Torch TORCH_INCLUDE_DIRS: ${TORCH_INCLUDE_DIRS}")
 
 # diopi
 set(WITH_DIOPI "${CMAKE_SOURCE_DIR}/third_party/DIOPI")
 add_library(diopi_impl SHARED IMPORTED)
-set_target_properties(diopi_impl PROPERTIES
-    IMPORTED_LOCATION "${WITH_DIOPI}/impl/lib/libdiopi_impl.so")
+set_target_properties(
+  diopi_impl PROPERTIES IMPORTED_LOCATION
+                        "${WITH_DIOPI}/impl/lib/libdiopi_impl.so")
 target_include_directories(diopi_impl INTERFACE "${WITH_DIOPI}/proto/include")
 target_compile_definitions(diopi_impl INTERFACE DIOPI_ATTR_WEAK)
 
-if (LIBS)
+if(LIBS)
   add_subdirectory(torch_dipu/csrc_dipu)
 endif()
 
-if (TESTS)
+if(TESTS)
   add_subdirectory(tests/cpp)
 endif()
-
-
-
-
-
-

--- a/dipu/QuickStart.md
+++ b/dipu/QuickStart.md
@@ -72,10 +72,8 @@ sh template_build_sh builddp $DIPU_DEVICE $DIOPI_IMPL
 ```
 ### 2.1.4 验证DIPU
 ``` bash
-export DIOPI_ROOT=/home/$USER/code/dipu/third_party/DIOPI/impl/lib
 export DIPU_ROOT=/home/$USER/code/dipu/torch_dipu
-export LIBRARY_PATH=$DIPU_ROOT:$DIOPI_ROOT:$LIBRARY_PATH;
-export LD_LIBRARY_PATH=$DIPU_ROOT:$DIOPI_ROOT:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DIPU_ROOT:$LD_LIBRARY_PATH
 export PYTHONPATH=/home/$USER/code/dipu:$PYTHONPATH
 
 python tests/test_ops/archived/test_tensor_add.py
@@ -289,7 +287,7 @@ void createStream(deviceStream_t* stream, bool prior) {
 - 对应上述CMAKE的修改，我们应该修改我们的编译脚本，在cmake相关命令中，我们的`template_build_sh`里面使用了`DCAMB=ON`，将其修改为`DDROPLET=ON`
 
 ### 4.4 编译与测试
-- 根据DIPU的编译介绍，我们在编译了impl之后，使用其编译脚本编译C++ ext和Python链接部分（脚本中`builddl`和`builddp`），这里需要注意编译之后将`LIBRARY_PATH`、`LD_LIBRARY_PATH`、`PYTHONPATH`都设置好避免后续使用出现问题
+- 根据DIPU的编译介绍，我们在编译了impl之后，使用其编译脚本编译C++ ext和Python链接部分（脚本中`builddl`和`builddp`），这里需要注意编译之后将 `LD_LIBRARY_PATH`、`PYTHONPATH`都设置好避免后续使用出现问题
 - `dipu/tests`文件夹中有许多基础功能的测试，建议首先尝试测试`python -u dipu/tests/test_ops/archived/test_tensor_add.py`，该文件测试跑通基本意味着我们的设备*runtime*接入没有问题了
 - 编译脚本参考[2.1.3](#213-编译dipu)，测试脚本可以参考[2.1.4](#214-验证dipu)
 

--- a/dipu/scripts/ci/ascend/ci_ascend_env.sh
+++ b/dipu/scripts/ci/ascend/ci_ascend_env.sh
@@ -3,8 +3,7 @@ source ${ENV_PATH}/pt2.0_ci
 
 export DIOPI_ROOT=$(pwd)/third_party/DIOPI/impl/lib
 export DIPU_ROOT=$(pwd)/torch_dipu
-export LIBRARY_PATH=${DIPU_ROOT}:${DIOPI_ROOT}:${LIBRARY_PATH}
-export LD_LIBRARY_PATH=${DIPU_ROOT}:${DIOPI_ROOT}:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${DIPU_ROOT}:${LD_LIBRARY_PATH}
 export PYTHONPATH=$(pwd):${PYTHONPATH}
 
 # MMCV build requirements

--- a/dipu/scripts/ci/camb/ci_camb_env.sh
+++ b/dipu/scripts/ci/camb/ci_camb_env.sh
@@ -12,7 +12,7 @@ export CXX=${GCC_ROOT}/bin/g++
 
 export DIOPI_ROOT=$(pwd)/third_party/DIOPI/impl/lib/
 export DIPU_ROOT=$(pwd)/torch_dipu
-export LIBRARY_PATH=$DIPU_ROOT:${DIOPI_ROOT}:${LIBRARY_PATH}; LD_LIBRARY_PATH=$DIPU_ROOT:$DIOPI_ROOT:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DIPU_ROOT:$LD_LIBRARY_PATH
 export PYTHONPATH=${PYTORCH_DIR}/install_path/lib/python3.8/site-packages:${PYTHONPATH}
 export PATH=${GCC_ROOT}/bin:${PYTORCH_DIR}/install_path/bin:${CONDA_ROOT}/envs/dipu_poc/bin:${CONDA_ROOT}/bin:${PATH}
 export LD_PRELOAD=${GCC_ROOT}/lib64/libstdc++.so.6

--- a/dipu/scripts/ci/camb/ci_camb_script.sh
+++ b/dipu/scripts/ci/camb/ci_camb_script.sh
@@ -47,7 +47,6 @@ function build_diopi_lib() {
 function build_dipu_lib() {
     echo "building dipu_lib:$(pwd)"
     echo  "DIOPI_ROOT:${DIOPI_ROOT}"
-    export LIBRARY_PATH=$DIOPI_ROOT:$LIBRARY_PATH;
     config_dipu_camb_cmake 2>&1 | tee ./cmake_camb.log
     cd build && make -j8  2>&1 | tee ./build.log &&  cd ..
     mv ./build/torch_dipu/csrc_dipu/libtorch_dipu.so   ./torch_dipu

--- a/dipu/scripts/ci/nv/ci_nv_env.sh
+++ b/dipu/scripts/ci/nv/ci_nv_env.sh
@@ -25,7 +25,7 @@ export DIPU_ROOT=$(pwd)/torch_dipu
 export DIOPI_PATH=$(pwd)/third_party/DIOPI/proto
 export DIPU_PATH=${DIPU_ROOT}
 export PYTORCH_DIR=${PLATFORM}/env/miniconda3.8/envs/pt2.0_diopi/lib/python3.8/site-packages
-export LIBRARY_PATH=$DIPU_ROOT:${DIOPI_ROOT}:${LIBRARY_PATH}; LD_LIBRARY_PATH=$DIPU_ROOT:$DIOPI_ROOT:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DIPU_ROOT:$LD_LIBRARY_PATH
 export PYTHONPATH=${PYTORCH_DIR}:${PYTHONPATH}
 export PATH=${GCC_ROOT}/bin:${CONDA_ROOT}/envs/dipu_poc/bin:${CONDA_ROOT}/bin:${PLATFORM}/dep/binutils-2.27/bin:${PATH}
 export LD_PRELOAD=${GCC_ROOT}/lib64/libstdc++.so.6

--- a/dipu/scripts/ci/nv/ci_nv_script.sh
+++ b/dipu/scripts/ci/nv/ci_nv_script.sh
@@ -46,7 +46,6 @@ function build_dipu_lib() {
     echo "building dipu_lib:$(pwd)"
     echo  "DIOPI_ROOT:${DIOPI_ROOT}"
     export DIOPI_BUILD_TESTRT=1
-    export LIBRARY_PATH=$DIOPI_ROOT:$LIBRARY_PATH;
     config_dipu_nv_cmake 2>&1 | tee ./cmake_nv.log
     cd build && make -j8  2>&1 | tee ./build.log &&  cd ..
     mv ./build/torch_dipu/csrc_dipu/libtorch_dipu.so   ./torch_dipu

--- a/dipu/scripts/ci/topsrider/ci_topsrider_env.sh
+++ b/dipu/scripts/ci/topsrider/ci_topsrider_env.sh
@@ -7,7 +7,7 @@ export DIPU_LOCAL_DIR=/path/to/dipu
 
 export DIOPI_ROOT=${DIPU_LOCAL_DIR}/third_party/DIOPI/impl/lib
 export DIPU_ROOT=${DIPU_LOCAL_DIR}/torch_dipu
-export LIBRARY_PATH=$DIPU_ROOT:${DIOPI_ROOT}:${LIBRARY_PATH}; LD_LIBRARY_PATH=$DIPU_ROOT:$DIOPI_ROOT:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DIPU_ROOT:$LD_LIBRARY_PATH
 export PYTHONPATH=${CONDA_ROOT}/envs/dipu/lib/python3.8:${DIPU_LOCAL_DIR}:${PYTHONPATH}
 export PATH=${PYTORCH_DIR}/build/bin:${CONDA_ROOT}/envs/dipu/bin:${CONDA_ROOT}/bin:${PATH}
 

--- a/dipu/setup.py
+++ b/dipu/setup.py
@@ -123,10 +123,10 @@ class CppExtensionBuilder:
         return CppExtensionBuilder.extcamb('torch_dipu._C',
             sources=["torch_dipu/csrc_dipu/stub.cpp"],
             libraries=["torch_dipu_python", "torch_dipu"],
-            include_dirs= CppExtensionBuilder.include_directories,
-            extra_compile_args= CppExtensionBuilder.extra_compile_args + ['-fstack-protector-all'],
-            library_dirs=["./build/torch_dipu/csrc_dipu"],
-            extra_link_args= CppExtensionBuilder.extra_link_args + ['-Wl,-rpath,$ORIGIN/lib'],
+            include_dirs=CppExtensionBuilder.include_directories,
+            extra_compile_args=CppExtensionBuilder.extra_compile_args + ['-fstack-protector-all'],
+            library_dirs=["torch_dipu"],
+            extra_link_args=CppExtensionBuilder.extra_link_args + ['-Wl,-rpath,$ORIGIN/torch_dipu'],
         )
 
     @staticmethod

--- a/dipu/template_build_sh
+++ b/dipu/template_build_sh
@@ -42,9 +42,6 @@ function build_diopi_lib() {
 }
 
 function build_dipu_lib() {
-    export DIOPI_ROOT=$PWD/third_party/DIOPI/impl/lib/
-    export LIBRARY_PATH=$DIOPI_ROOT:$LIBRARY_PATH;
-
     autogen_diopi_wrapper
     mkdir -p build
     config_dipu_cmake

--- a/dipu/tests/cpp/CMakeLists.txt
+++ b/dipu/tests/cpp/CMakeLists.txt
@@ -1,7 +1,4 @@
-
-FILE(GLOB test1
-testrt.cpp
-)
+file(GLOB test1 testrt.cpp)
 
 # temporarily: enhance to use the same configuration as lib
 set(DIPU_PATH ${PROJECT_SOURCE_DIR}/torch_dipu/)
@@ -13,9 +10,8 @@ link_directories(${VENDOR_LIB_DIRS})
 
 # to use gtest
 set(ALL_TESTS test_tensor_add test_relu testrt)
-set(DIPU_LIB "torch_dipu")
-foreach (tname ${ALL_TESTS})
-    add_executable(${tname} ${tname}.cpp)
-    target_link_libraries(${tname} ${DIPU_LIB})
-    target_link_libraries(${tname} c10 torch torch_cpu)
-endforeach (tname)
+foreach(tname ${ALL_TESTS})
+  add_executable(${tname} ${tname}.cpp)
+  target_link_libraries(${tname} torch_dipu)
+  target_link_libraries(${tname} c10 torch torch_cpu)
+endforeach(tname)

--- a/dipu/tests/cpp/CMakeLists.txt
+++ b/dipu/tests/cpp/CMakeLists.txt
@@ -13,7 +13,7 @@ link_directories(${VENDOR_LIB_DIRS})
 
 # to use gtest
 set(ALL_TESTS test_tensor_add test_relu testrt)
-set(DIPU_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../../torch_dipu/libtorch_dipu.so")
+set(DIPU_LIB "torch_dipu")
 foreach (tname ${ALL_TESTS})
     add_executable(${tname} ${tname}.cpp)
     target_link_libraries(${tname} ${DIPU_LIB})

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -2,7 +2,7 @@ set(DIPU_LIB torch_dipu)
 set(DIPU_PYTHON_LIB torch_dipu_python)
 
 # python path
-include_directories(${PYTHON_INCLUDE_DIR})
+include_directories(SYSTEM ${PYTHON_INCLUDE_DIR})
 
 # dipu include path
 set(DIPU_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../)

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -12,22 +12,25 @@ set(DIST_DIR ${DIPU_PATH}/dist/include)
 include_directories(${DIST_DIR})
 
 # src
-file(GLOB RT_SRC_FILES
-    runtime/core/guardimpl/*.cpp
-    runtime/core/allocator/*.cpp
-    runtime/core/DIPU*.cpp
-    runtime/core/MemChecker.cpp
-    runtime/distributed/*.cpp
-    runtime/devproxy/*.cpp
-)
+file(
+  GLOB
+  RT_SRC_FILES
+  runtime/core/guardimpl/*.cpp
+  runtime/core/allocator/*.cpp
+  runtime/core/DIPU*.cpp
+  runtime/core/MemChecker.cpp
+  runtime/distributed/*.cpp
+  runtime/devproxy/*.cpp)
 
-file(GLOB OP_SRC_FILES aten/RegisterDIPU.cpp
-    aten/CPUFallback.cpp
-    aten/util/*.cpp
-    aten/ops/*Kernel*.cpp
-    aten/ops/DIPUAmp.cpp
-    aten/ops/CustomFallbackFunctionsForAmpGradScaler.cpp
-)
+file(
+  GLOB
+  OP_SRC_FILES
+  aten/RegisterDIPU.cpp
+  aten/CPUFallback.cpp
+  aten/util/*.cpp
+  aten/ops/*Kernel*.cpp
+  aten/ops/DIPUAmp.cpp
+  aten/ops/CustomFallbackFunctionsForAmpGradScaler.cpp)
 
 file(GLOB BASE_FILES base/*.cpp)
 file(GLOB UTILS_FILES utils/*.cpp)
@@ -39,11 +42,6 @@ add_subdirectory(vendor/${UsedVendor})
 include_directories(SYSTEM ${VENDOR_INCLUDE_DIRS})
 link_directories(${VENDOR_LIB_DIRS})
 
-
-# if (${UsedVendor} STREQUAL ${VendorMLU})
-#     message(STATUS "---- vendor specific (but shouldn't exist)----")
-# endif()
-
 set(SOURCE_FILES
     ${RT_SRC_FILES}
     ${OP_SRC_FILES}
@@ -51,48 +49,49 @@ set(SOURCE_FILES
     ${BASE_FILES}
     ${UTILS_FILES}
     ${VENDOR_FILES}
-    ${PROFILER_FILES}
-)
+    ${PROFILER_FILES})
 
 add_library(${DIPU_LIB} SHARED ${SOURCE_FILES})
 
 # link
 target_link_libraries(${DIPU_LIB} ${DIPU_VENDOR_LIB})
 
-target_link_libraries(${DIPU_LIB}  -Wl,--no-as-needed diopi_impl -Wl,--as-needed)
-target_link_libraries(${DIPU_LIB}  c10 torch torch_cpu)
+target_link_libraries(${DIPU_LIB} -Wl,--no-as-needed diopi_impl -Wl,--as-needed)
+target_link_libraries(${DIPU_LIB} c10 torch torch_cpu)
 
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(${DIPU_LIB} Threads::Threads)
 
-## copy vendor header file
+# copy vendor header file
 set(VENDOR_DIST "${DIST_DIR}/csrc_dipu/vendor/")
 set(VENDOR_HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vendor/${UsedVendor}")
-add_custom_command(OUTPUT vendor_include
-    COMMAND mkdir -p ${VENDOR_DIST}
-    COMMAND cmake -E create_symlink ${VENDOR_HEADER_DIR}/vendorapi.h ${VENDOR_DIST}/vendorapi.h)
-if (EXISTS "${VENDOR_HEADER_DIR}/vendor_autocast.h" AND
-        NOT IS_DIRECTORY "${VENDOR_HEADER_DIR}/vendor_autocast.h")
-    add_custom_command(OUTPUT vendor_include APPEND
-        COMMAND cmake -E create_symlink ${VENDOR_HEADER_DIR}/vendor_autocast.h ${VENDOR_DIST}/vendor_autocast.h)
+add_custom_command(
+  OUTPUT vendor_include
+  COMMAND mkdir -p ${VENDOR_DIST}
+  COMMAND cmake -E create_symlink ${VENDOR_HEADER_DIR}/vendorapi.h
+          ${VENDOR_DIST}/vendorapi.h)
+if(EXISTS "${VENDOR_HEADER_DIR}/vendor_autocast.h"
+   AND NOT IS_DIRECTORY "${VENDOR_HEADER_DIR}/vendor_autocast.h")
+  add_custom_command(
+    OUTPUT vendor_include
+    APPEND
+    COMMAND cmake -E create_symlink ${VENDOR_HEADER_DIR}/vendor_autocast.h
+            ${VENDOR_DIST}/vendor_autocast.h)
 else()
-    target_compile_definitions(${DIPU_LIB} PRIVATE DIPU_NO_VENDOR_AUTOCAST)
+  target_compile_definitions(${DIPU_LIB} PRIVATE DIPU_NO_VENDOR_AUTOCAST)
 endif()
 add_custom_target(copy_include DEPENDS vendor_include)
 add_dependencies(${DIPU_LIB} copy_include)
 
-
 # --------build bind in python --------------
-file(GLOB BIND_SRC_FILES binding/Export*.cpp
-  binding/patch*.cpp
-)
-set(BIND_FILES
-    ${BIND_SRC_FILES}
-)
+file(GLOB BIND_SRC_FILES binding/Export*.cpp binding/patch*.cpp)
+set(BIND_FILES ${BIND_SRC_FILES})
 add_library(${DIPU_PYTHON_LIB} SHARED ${BIND_SRC_FILES})
-# default hidden setting scope is incorrect and cannot open now because it cause diopirt hidden,
-# so temporarily use this target level setting. enhance in future. todo
-set_target_properties(${DIPU_PYTHON_LIB} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+# TODO: default hidden setting scope is incorrect and cannot open now because it
+# cause diopirt hidden, so temporarily use this target level setting. enhance in
+# future.
+set_target_properties(${DIPU_PYTHON_LIB} PROPERTIES CXX_VISIBILITY_PRESET
+                                                    hidden)
 target_link_libraries(${DIPU_PYTHON_LIB} ${DIPU_LIB})

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -69,6 +69,11 @@ endif()
 target_link_libraries(${DIPU_LIB}  -Wl,--no-as-needed ${DIOPI_IMPL_LIB} -Wl,--as-needed)
 target_link_libraries(${DIPU_LIB}  c10 torch torch_cpu)
 
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(${DIPU_LIB} Threads::Threads)
+
 ## copy vendor header file
 set(VENDOR_DIST "${DIST_DIR}/csrc_dipu/vendor/")
 set(VENDOR_HEADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/vendor/${UsedVendor}")

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -59,14 +59,7 @@ add_library(${DIPU_LIB} SHARED ${SOURCE_FILES})
 # link
 target_link_libraries(${DIPU_LIB} ${DIPU_VENDOR_LIB})
 
-if(DEFINED ENV{DIOPI_IMPL_LIB})
-  find_library(DIOPI_IMPL_LIB NAMES diopi_impl HINTS ENV DIOPI_IMPL_LIB REQUIRED)
-else()
-  set(DIOPI_IMPL_LIB diopi_impl)
-endif()
-
-# need export LIBRARY_PATH=$DIOPI_ROOT:$LIBRARY_PATH;
-target_link_libraries(${DIPU_LIB}  -Wl,--no-as-needed ${DIOPI_IMPL_LIB} -Wl,--as-needed)
+target_link_libraries(${DIPU_LIB}  -Wl,--no-as-needed diopi_impl -Wl,--as-needed)
 target_link_libraries(${DIPU_LIB}  c10 torch torch_cpu)
 
 set(CMAKE_THREAD_PREFER_PTHREAD ON)


### PR DESCRIPTION
### 主要修改
- 将编译好的 DIOPI 以 imported 形式引入，可以以 WITH_DIOPI 的 CMake 参数设置位置（一般默认值就能用）
  - (in future PR) 将支持 WITH_DIOPI=internal 来就地编译 DIOPI
- 删除所有 LIBRARY_PATH 的需求（会影响 rpath），并正确设置 DIOPI 和 DIPU 的 rpath
  - 删除对 DIOPI LD_LIBRARY_PATH 的需求（由 rpath 寻找），因此总是可以正确找到编译 DIPU 时用的版本

### 其他修改
- 修复并优化 cpp test 的 CMake
- 格式化所有受影响的 CMake
- 将一些非 DIPU 的 include dir 设置为 isystem