### PR TITLE
fix bug for is_cuda and fix syncbn test case

### DIFF
--- a/dipu/tests/test_ops/archived/test_SyncBN.py
+++ b/dipu/tests/test_ops/archived/test_SyncBN.py
@@ -27,15 +27,15 @@ class TestSchema(unittest.TestCase):
     def test_batch_norm_gather_stats_with_counts(self):
         if (torch.cuda.is_available() is False):
             return
-        workpiece = 7
+        world_size = 7
         input = torch.rand(2, 8, 32, 56, 56)
-        mean_all = torch.rand(workpiece, 8)
-        invstd_all = torch.rand(workpiece, 8)
+        mean_all = torch.rand(world_size, 8)
+        invstd_all = torch.rand(world_size, 8)
         running_mean = torch.rand(8)
         running_var = torch.rand(8)
         momentum = 1e-4
         eps = 1e-5
-        count_all = torch.rand(workpiece * 8)
+        count_all = torch.rand(world_size)
         res1 = self._test_bng(input, mean_all, invstd_all, running_mean, running_var, momentum, eps, count_all, device_cuda)
         res2 = self._test_bng(input, mean_all, invstd_all, running_mean, running_var, momentum, eps, count_all, device_dipu)
         self._test_res(res1, res2)

--- a/dipu/tests/test_ops/archived/test_storage.py
+++ b/dipu/tests/test_ops/archived/test_storage.py
@@ -23,7 +23,7 @@ def test_stor1():
 
   snew = s1.resize_(0)
   assert(snew.size() == 0)
-  assert(x1.is_dipu() == True)
+  assert(x1.is_dipu == True)
 
 if __name__ == '__main__':
     test_stor1()

--- a/dipu/tests/test_ops/archived/test_storage.py
+++ b/dipu/tests/test_ops/archived/test_storage.py
@@ -24,6 +24,7 @@ def test_stor1():
   snew = s1.resize_(0)
   assert(snew.size() == 0)
   assert(x1.is_dipu == True)
+  assert(x1.is_cuda == True)
 
 if __name__ == '__main__':
     test_stor1()

--- a/dipu/torch_dipu/__init__.py
+++ b/dipu/torch_dipu/__init__.py
@@ -41,7 +41,7 @@ def apply_tensor_method_patch():
     torch.Tensor.new =  GetDeviceProxy(torch.Tensor.new,  pos = -1)
 
     torch.Tensor.dipu = GetDeviceProxy(_C.dipu)
-    torch.Tensor.is_dipu = property(GetDeviceProxy(_C.is_dipu))
+    torch.Tensor.is_dipu = property(_C.is_dipu)
 
     # if we replace in pybind layer, the func torch capacity in default python_variable_methods.cpp 
     # THPVariable_record_stream() will loss. so we currently replace in the python layer.

--- a/dipu/torch_dipu/__init__.py
+++ b/dipu/torch_dipu/__init__.py
@@ -41,7 +41,7 @@ def apply_tensor_method_patch():
     torch.Tensor.new =  GetDeviceProxy(torch.Tensor.new,  pos = -1)
 
     torch.Tensor.dipu = GetDeviceProxy(_C.dipu)
-    torch.Tensor.is_dipu = GetDeviceProxy(_C.is_dipu)
+    torch.Tensor.is_dipu = property(GetDeviceProxy(_C.is_dipu))
 
     # if we replace in pybind layer, the func torch capacity in default python_variable_methods.cpp 
     # THPVariable_record_stream() will loss. so we currently replace in the python layer.


### PR DESCRIPTION
# fix bug for is_cuda
pytorch的is_cuda不是一个函数调用是一个属性调用

a = torch.tensor([2.2,13])
print(a.is_cuda)

DIPU是函数调用形式
print(a.is_cuda())
通过把函数改写为属性解决这个问题

解决办法from @wey-code 

-----------------------
# fix syncbn test case
Previously, there was a problem with the input data structure（count_all）of test_batch_norm_gather_stats_with_counts, which would cause the test to fail on camb. This PR fixes the problem.