### PR TITLE
fix bind error of erfinv: diopiErf -> diopiErfinv

### DIFF
--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -1683,10 +1683,10 @@
   interface: diopiCdistBackward(ctx, grad_input, grad, x1, x2, p, cdist)
 
 - schema: "erfinv.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)"
-  interface: diopiErf(ctx, out, self)
+  interface: diopiErfinv(ctx, out, self)
 
 - schema: "erfinv_(Tensor(a!) self) -> Tensor(a!)"
-  interface: diopiErfInp(ctx, self)
+  interface: diopiErfinvInp(ctx, self)
 
 - schema: "polar(Tensor abs, Tensor angle) -> Tensor"
   custom_code_at_the_beginning: |


### PR DESCRIPTION
test_erfinv.py missed `assert` so this error is not detected. The updated test is not uploaded since I am rewriting all tests.