### PR TITLE
If vendor is cuda, its ability to support bf16 remains the same as the default.

### DIFF
--- a/dipu/tests/test_ops/archived/test_autocast.py
+++ b/dipu/tests/test_ops/archived/test_autocast.py
@@ -7,6 +7,9 @@ from torch.cuda.amp import autocast as autocast
 a_float32 = torch.rand((8, 8), device="cuda")
 b_float32 = torch.rand((8, 8), device="cuda")
 
+with torch.autocast("cuda"):
+    pass
+
 with torch.autocast("cuda", torch.float16):
     c_float16 = torch.mm(a_float32, b_float32)
     with torch.autocast("cuda", enabled=False):

--- a/dipu/tests/test_ops/archived/test_autocast.py
+++ b/dipu/tests/test_ops/archived/test_autocast.py
@@ -7,6 +7,9 @@ from torch.cuda.amp import autocast as autocast
 a_float32 = torch.rand((8, 8), device="cuda")
 b_float32 = torch.rand((8, 8), device="cuda")
 
+# Autocast does not need to pass in torch.dtype, 
+# in which case the default data type will be used.
+# (We changed the default data type to fp16 in dipu/torch_dipu/dipu/amp.py)
 with torch.autocast("cuda"):
     pass
 

--- a/dipu/torch_dipu/__init__.py
+++ b/dipu/torch_dipu/__init__.py
@@ -116,7 +116,11 @@ def apply_amp_patch():
     torch.set_autocast_gpu_dtype = dipu.amp.set_autocast_dipu_dtype
     torch.set_autocast_enabled = dipu.amp.set_autocast_dipu_enabled
     torch.is_autocast_enabled = dipu.amp.is_autocast_dipu_enabled
-    torch.cuda.is_bf16_supported = dipu.amp.is_bf16_supported
+    # If vendor is cuda, its ability to support bf16 remains the same as the default.
+    # (which depends on the Compute Capability)
+    if (dipu.vendor_type != "CUDA"):
+        torch.cuda.is_bf16_supported = dipu.amp.is_bf16_supported
+
 
 
 def apply_patches():

--- a/dipu/torch_dipu/__init__.py
+++ b/dipu/torch_dipu/__init__.py
@@ -23,6 +23,7 @@ from .profiler.profiler import dipu_profiler, dipu_kineto_available
 from .dipu.dataloader import apply_dataloader_patch
 from .dipu.generator import apply_generator_patch
 from .dipu.streams import apply_stream_patch, _dipu_record_stream
+from .dipu.amp import apply_amp_patch
 
 # mock device functions in generated/python_variable_methods.cpp
 def apply_tensor_method_patch():
@@ -109,17 +110,6 @@ def apply_profiler_patch():
     setattr(torch.profiler, 'kineto_available', dipu_kineto_available)
     setattr(torch.autograd.profiler, 'kineto_available', dipu_kineto_available)
     torch.profiler.profile = dipu_profiler
-
-
-def apply_amp_patch():
-    torch.get_autocast_gpu_dtype = dipu.amp.get_autocast_dipu_dtype
-    torch.set_autocast_gpu_dtype = dipu.amp.set_autocast_dipu_dtype
-    torch.set_autocast_enabled = dipu.amp.set_autocast_dipu_enabled
-    torch.is_autocast_enabled = dipu.amp.is_autocast_dipu_enabled
-    # If vendor is cuda, its ability to support bf16 remains the same as the default.
-    # (which depends on the Compute Capability)
-    if (dipu.vendor_type != "CUDA"):
-        torch.cuda.is_bf16_supported = dipu.amp.is_bf16_supported
 
 
 

--- a/dipu/torch_dipu/dipu/amp.py
+++ b/dipu/torch_dipu/dipu/amp.py
@@ -32,4 +32,8 @@ def apply_amp_patch():
     # (which depends on the Compute Capability)
     if (dipu.vendor_type != "CUDA"):
         torch.cuda.is_bf16_supported = is_bf16_supported
+
+    # autocast_xpu_dtype is defined in ATen/autocast_mode.cpp with default value kBFloat16.
+    # it is a thread local so this set only change default value in main thread.
+    # ** need enhance to let all threads has same default type.
     set_autocast_dipu_dtype(torch.float16)

--- a/dipu/torch_dipu/dipu/amp.py
+++ b/dipu/torch_dipu/dipu/amp.py
@@ -1,4 +1,5 @@
-from torch_dipu import _C
+from torch_dipu import _C, dipu
+import torch
 
 
 def get_autocast_dipu_dtype():
@@ -21,3 +22,14 @@ def set_autocast_dipu_dtype(dtype):
 # This function needs to be improved in the future and customized for different device.
 def is_bf16_supported():
     return False
+
+def apply_amp_patch():
+    torch.get_autocast_gpu_dtype = get_autocast_dipu_dtype
+    torch.set_autocast_gpu_dtype = set_autocast_dipu_dtype
+    torch.set_autocast_enabled = set_autocast_dipu_enabled
+    torch.is_autocast_enabled = is_autocast_dipu_enabled
+    # If vendor is cuda, its ability to support bf16 remains the same as the default.
+    # (which depends on the Compute Capability)
+    if (dipu.vendor_type != "CUDA"):
+        torch.cuda.is_bf16_supported = is_bf16_supported
+    set_autocast_dipu_dtype(torch.float16)


### PR DESCRIPTION
用于修改在a100及以上不能跑bf16的问题，让dipu在cuda上的行为和默认保持一致
同时将DIPU的默认dtype从bf16修改为fp16，避免一些厂商不支持bf16的问题。