### PR TITLE
Make all DIPU build(except DIOPI) in CMake

### DIFF
--- a/dipu/CMakeLists.txt
+++ b/dipu/CMakeLists.txt
@@ -118,6 +118,10 @@ else()
     set(DIOPI_PROTO_PATH "${PROJECT_SOURCE_DIR}/third_party/DIOPI/proto")
     include_directories(${DIOPI_PROTO_PATH}/include)
 endif()
+
+set(DIOPI_IMPL_LIB_PATH "${PROJECT_SOURCE_DIR}/third_party/DIOPI/impl/lib")
+set(DIOPI_IMPL_PATH "${PROJECT_SOURCE_DIR}/third_party/DIOPI/impl/")
+
 add_definitions(-DDIOPI_ATTR_WEAK)
 
 if (LIBS)

--- a/dipu/scripts/ci/camb/ci_camb_script.sh
+++ b/dipu/scripts/ci/camb/ci_camb_script.sh
@@ -2,13 +2,6 @@
 set -e
 echo "pwd: $(pwd)"
 
-function build_dipu_py() {
-    echo "building dipu_py:$(pwd)"
-    export CMAKE_BUILD_TYPE=Release
-    export MAX_JOBS=12
-    python setup.py build_ext 2>&1 | tee ./setup.log
-    mv build/python_ext/torch_dipu/_C.cpython-*.so torch_dipu
-}
 
 function config_dipu_camb_cmake() {
     mkdir -p build && cd ./build && rm -rf ./*
@@ -18,24 +11,6 @@ function config_dipu_camb_cmake() {
     cd ../
 }
 
-function autogen_diopi_wrapper() {
-    python scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py                             \
-        --config scripts/autogen_diopi_wrapper/diopi_functions.yaml                           \
-        --out torch_dipu/csrc_dipu/aten/ops/AutoGenedKernels.cpp                              \
-        --autocompare  False                                                                  \
-        --print_func_call_info True                                                           \
-        --print_op_arg True                                                                   \
-        --fun_config_dict '{"current_device": "camb"}'                                        \
-        --use_diopi_adapter False                                                             \
-        # --diopi_adapter_header third_party/DIOPI/proto/include/diopi/diopi_adaptors.hpp
-
-    # only test mulity config autogen
-    python scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py                   \
-        --config scripts/autogen_diopi_wrapper/custom_diopi_functions.yaml          \
-        --out torch_dipu/csrc_dipu/aten/ops/CustomAutoGenedKernels.cpp              \
-        --use_diopi_adapter False                                                   \
-
-}
 
 function build_diopi_lib() {
     cd third_party/DIOPI/impl
@@ -58,19 +33,12 @@ case $1 in
     build_dipu)
         (
             build_diopi_lib
-            autogen_diopi_wrapper
             build_dipu_lib
-            build_dipu_py
         ) || exit -1;;
     build_diopi)
         build_diopi_lib || exit -1;;
-    build_autogen_diopi_wrapper)
-        autogen_diopi_wrapper || exit -1;;
     build_dipu_only)
-        (
-         autogen_diopi_wrapper
-         build_dipu_lib
-         build_dipu_py) || exit -1;;
+         build_dipu_lib || exit -1;;
     *)
         echo -e "[ERROR] Incorrect option:" $1;
 esac

--- a/dipu/scripts/ci/nv/ci_nv_script.sh
+++ b/dipu/scripts/ci/nv/ci_nv_script.sh
@@ -2,13 +2,6 @@
 set -e
 echo "pwd: $(pwd)"
 
-function build_dipu_py() {
-    echo "building dipu_py:$(pwd)"
-    export CMAKE_BUILD_TYPE=Release
-    export MAX_JOBS=12
-    python setup.py build_ext 2>&1 | tee ./setup.log
-    mv build/python_ext/torch_dipu/_C.cpython-*.so torch_dipu
-}
 
 function config_dipu_nv_cmake() {
     # export NCCL_ROOT="you nccl path should exist"
@@ -18,17 +11,6 @@ function config_dipu_nv_cmake() {
         -DDEVICE=cuda \
         -DENABLE_COVERAGE=${USE_COVERAGE}
     cd ../
-}
-
-function autogen_diopi_wrapper() {
-    python scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py                   \
-        --config scripts/autogen_diopi_wrapper/diopi_functions.yaml                 \
-        --out torch_dipu/csrc_dipu/aten/ops/AutoGenedKernels.cpp                    \
-        --use_diopi_adapter False                                                   \
-        --autocompare False                                                         \
-        --print_func_call_info True                                                 \
-        --print_op_arg True                                                         \
-        --fun_config_dict '{"current_device": "cuda"}'
 }
 
 function build_diopi_lib() {
@@ -57,16 +39,12 @@ case $1 in
     build_dipu)
         (
             build_diopi_lib
-            autogen_diopi_wrapper
             build_dipu_lib
-            build_dipu_py
         ) \
         || exit -1;;
     build_dipu_only)
         (
-            autogen_diopi_wrapper
             build_dipu_lib
-            build_dipu_py
         ) \
         || exit -1;;
     *)

--- a/dipu/setup.py
+++ b/dipu/setup.py
@@ -8,177 +8,15 @@ import shutil
 import subprocess
 import sys
 import platform
-
-import distutils.ccompiler
-import distutils.command.clean
-from sysconfig import get_paths
-from distutils.version import LooseVersion
-from distutils.command.build_py import build_py
-from setuptools.command.build_ext import build_ext
-from setuptools.command.install import install
+import setuptools
 from setuptools import setup, distutils, Extension
-from setuptools.command.build_clib import build_clib
-from setuptools.command.egg_info import egg_info
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 VERSION = '0.1'
 
-def which(thefile):
-    path = os.environ.get("PATH", os.defpath).split(os.pathsep)
-    for d in path:
-        fname = os.path.join(d, thefile)
-        fnames = [fname]
-        if sys.platform == 'win32':
-            exts = os.environ.get('PATHEXT', '').split(os.pathsep)
-            fnames += [fname + ext for ext in exts]
-        for name in fnames:
-            if os.access(name, os.F_OK | os.X_OK) and not os.path.isdir(name):
-                return name
-    return None
-
-def get_cmake_command():
-    def _get_version(cmd):
-        for line in subprocess.check_output([cmd, '--version']).decode('utf-8').split('\n'):
-            if 'version' in line:
-                return LooseVersion(line.strip().split(' ')[2])
-        raise RuntimeError('no version found')
-    "Returns cmake command."
-    cmake_command = 'cmake'
-    cmake3 = which('cmake3')
-    cmake = which('cmake')
-    if cmake3 is not None and _get_version(cmake3) >= LooseVersion("3.10.0"):
-        cmake_command = 'cmake3'
-        return cmake_command
-    elif cmake is not None and _get_version(cmake) >= LooseVersion("3.10.0"):
-        return cmake_command
-    else:
-        raise RuntimeError('no cmake or cmake3 with version >= 3.10.0 found')
-
-def get_build_type():
-    build_type = 'Debug'
-    if os.getenv('Release', default='0').upper() in ['ON', '1', 'YES', 'TRUE', 'Y']:
-        build_type = 'Release'
-
-    if  os.getenv('REL_WITH_DEB_INFO', default='0').upper() in ['ON', '1', 'YES', 'TRUE', 'Y']:
-        build_type = 'RelWithDebInfo'
-
-    return build_type
-
 def get_pytorch_dir():
     import torch
     return os.path.dirname(os.path.abspath(torch.__file__))
-
-class CPPLibBuild(build_clib, object):
-    def run(self):
-        cmake = get_cmake_command()
-
-        if cmake is None:
-            raise RuntimeError(
-                "CMake must be installed to build the following extensions: " +
-                ", ".join(e.name for e in self.extensions))
-        self.cmake = cmake
-
-        build_dir = os.path.join(BASE_DIR, "build")
-        build_type_dir = os.path.join(build_dir, get_build_type())
-        output_lib_path = os.path.join(build_type_dir, "torch_dipu/lib")
-        os.makedirs(build_type_dir, exist_ok=True)
-        os.makedirs(output_lib_path, exist_ok=True)
-        self.build_lib =  os.path.relpath(os.path.join(build_dir, "torch_dipu"))
-        self.build_temp =  os.path.relpath(build_type_dir)
-        cmake_args = [
-            '-DCMAKE_BUILD_TYPE=' + get_build_type(),
-            # '-DCMAKE_INSTALL_PREFIX=' + os.path.abspath(output_lib_path),
-            # '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + os.path.abspath(output_lib_path),
-            # '-DTORCHDIPU_INSTALL_LIBDIR=' + os.path.abspath(output_lib_path),
-            # '-DPYTORCH_INSTALL_DIR=' + get_pytorch_dir()
-        ]
-        build_args = ['-j', 12]
-        subprocess.check_call([self.cmake, BASE_DIR] + cmake_args, cwd=build_type_dir, env=os.environ)
-        subprocess.check_call(['make'] + build_args, cwd=build_type_dir, env=os.environ)
-
-class CppExtensionBuilder:
-    include_directories = [
-        BASE_DIR +"/torch_dipu",
-    ]
-
-    extra_link_args = []
-
-    DEBUG = (os.getenv('DEBUG', default='').upper() in ['ON', '1', 'YES', 'TRUE', 'Y'])
-
-    extra_compile_args = [
-        '-std=c++14',
-        '-Wno-sign-compare',
-        '-Wno-deprecated-declarations',
-        '-Wno-return-type',
-    ]
-    if DEBUG:
-        extra_compile_args += ['-O0', '-g']
-        extra_link_args += ['-O0', '-g', '-Wl,-z,now']
-    else:
-        # extra_compile_args += ['-DNDEBUG']
-        extra_link_args += ['-Wl,-z,now,-s']
-
-    @staticmethod
-    def genDIPUExt():
-        return CppExtensionBuilder.extcamb('torch_dipu._C',
-            sources=["torch_dipu/csrc_dipu/stub.cpp"],
-            libraries=["torch_dipu_python", "torch_dipu"],
-            include_dirs= CppExtensionBuilder.include_directories,
-            extra_compile_args= CppExtensionBuilder.extra_compile_args + ['-fstack-protector-all'],
-            library_dirs=["./build/torch_dipu/csrc_dipu"],
-            extra_link_args= CppExtensionBuilder.extra_link_args + ['-Wl,-rpath,$ORIGIN/lib'],
-        )
-
-    @staticmethod
-    def extcamb(name, sources, *args, **kwargs):
-        r'''
-        Creates a :class:`setuptools.Extension` for C++.
-        '''
-        pytorch_dir = get_pytorch_dir()
-        temp_include_dirs = kwargs.get('include_dirs', [])
-        temp_include_dirs.append(os.path.join(pytorch_dir, 'include'))
-        temp_include_dirs.append(os.path.join(pytorch_dir, 'include/torch/csrc/api/include'))
-        kwargs['include_dirs'] = temp_include_dirs
-
-        temp_library_dirs = kwargs.get('library_dirs', [])
-        temp_library_dirs.append(os.path.join(pytorch_dir, 'lib'))
-        kwargs['library_dirs'] = temp_library_dirs
-
-        libraries = kwargs.get('libraries', [])
-        libraries.append('c10')
-        libraries.append('torch')
-        libraries.append('torch_cpu')
-        libraries.append('torch_python')
-        kwargs['libraries'] = libraries
-        kwargs['language'] = 'c++'
-        return Extension(name, sources, *args, **kwargs)
-
-
-class BuildExt(build_ext, object):
-    def run(self):
-        self.build_lib =  os.path.relpath(os.path.join(BASE_DIR, f"build/python_ext"))
-        self.build_temp =  os.path.relpath(os.path.join(BASE_DIR, f"build/python_ext"))
-        super(BuildExt, self).run()
-
-
-def start_debug():
-    rank = 0
-    pid1 = os.getpid()
-    print("-------------------------print rank,:", rank, "pid1:", pid1)
-    if rank == 0:
-        #  time.sleep(15)
-        import ptvsd
-        host = "127.0.0.1" # or "localhost"
-        port = 12345
-        print("Waiting for debugger attach at %s:%s ......" % (host, port), flush=True)
-        ptvsd.enable_attach(address=(host, port), redirect_output=True)
-        ptvsd.wait_for_attach()
-
-# start_debug()
-
-# placeholder: autogen design.....
-# generate_bindings_code()
-
 
 setup(
     name="torch_dipu",
@@ -187,10 +25,6 @@ setup(
     url='https://github.com/DeepLink-org/dipu',
     packages=["torch_dipu"],
     ext_modules=[
-        CppExtensionBuilder.genDIPUExt(),
     ],
     cmdclass={
-        # build_clib not work now, need enhance
-        'build_clib': CPPLibBuild,
-        'build_ext': BuildExt,
     })

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(DIPU_LIB torch_dipu)
 set(DIPU_PYTHON_LIB torch_dipu_python)
+set(DIPU_AUTOGENED_KERNELS torch_dipu_autogened_kernels)
 
 # python path
 include_directories(${PYTHON_INCLUDE_DIR})
@@ -60,9 +61,9 @@ add_library(${DIPU_LIB} SHARED ${SOURCE_FILES})
 target_link_libraries(${DIPU_LIB} ${DIPU_VENDOR_LIB})
 
 if(DEFINED ENV{DIOPI_IMPL_LIB})
-  find_library(DIOPI_IMPL_LIB NAMES diopi_impl HINTS ENV DIOPI_IMPL_LIB REQUIRED)
+    find_library(DIOPI_IMPL_LIB NAMES diopi_impl HINTS ENV DIOPI_IMPL_LIB REQUIRED)
 else()
-  set(DIOPI_IMPL_LIB diopi_impl)
+    find_library(DIOPI_IMPL_LIB NAMES diopi_impl HINTS ${DIOPI_IMPL_LIB_PATH} REQUIRED)
 endif()
 
 # need export LIBRARY_PATH=$DIOPI_ROOT:$LIBRARY_PATH;
@@ -85,6 +86,31 @@ endif()
 add_custom_target(copy_include DEPENDS vendor_include)
 add_dependencies(${DIPU_LIB} copy_include)
 
+add_custom_target(${DIPU_AUTOGENED_KERNELS})
+add_dependencies(${DIPU_LIB} ${DIPU_AUTOGENED_KERNELS})
+
+set(DIPU_AUTOGEN_DIOPI_WRAPPER_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py" )
+set(DIPU_AUTOGEN_DIOPI_WRAPPER_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/autogen_diopi_wrapper/diopi_functions.yaml" )
+set(DIPU_AUTOGEN_DIOPI_WRAPPER_CUSTOM_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/../../scripts/autogen_diopi_wrapper/custom_diopi_functions.yaml" )
+set(DIPU_AUTOGENED_KERNELS_CPP "${CMAKE_CURRENT_SOURCE_DIR}/aten/ops/AutoGenedKernels.cpp")
+set(DIPU_CUSTOM_AUTOGENED_KERNELS_CPP "${CMAKE_CURRENT_SOURCE_DIR}/aten/ops/CustomAutoGenedKernels.cpp")
+
+if(${UsedVendor} STREQUAL "camb")
+    add_custom_command(OUTPUT ${DIPU_CUSTOM_AUTOGENED_KERNELS_CPP}   
+        COMMAND python ${DIPU_AUTOGEN_DIOPI_WRAPPER_SCRIPT}  --config ${DIPU_AUTOGEN_DIOPI_WRAPPER_CUSTOM_CONFIG}  --out ${DIPU_CUSTOM_AUTOGENED_KERNELS_CPP}  --use_diopi_adapter False 
+        DEPENDS ${DIPU_AUTOGEN_DIOPI_WRAPPER_SCRIPT} 
+                ${DIPU_AUTOGEN_DIOPI_WRAPPER_CUSTOM_CONFIG}
+    )
+    add_custom_target(autogen_diopi_custom_kernels_cpp DEPENDS ${DIPU_CUSTOM_AUTOGENED_KERNELS_CPP})
+    add_dependencies(${DIPU_AUTOGENED_KERNELS} autogen_diopi_custom_kernels_cpp)
+
+endif()
+
+add_custom_command(OUTPUT "${DIPU_AUTOGENED_KERNELS_CPP}"
+    COMMAND python "${DIPU_AUTOGEN_DIOPI_WRAPPER_SCRIPT}" --config "${DIPU_AUTOGEN_DIOPI_WRAPPER_CONFIG}"  --out "${DIPU_AUTOGENED_KERNELS_CPP}"  --use_diopi_adapter False  --autocompare False --print_func_call_info True  --print_op_arg True  --fun_config_dict '{\"current_device\": \"${UsedVendor}\"}'  DEPENDS "${DIPU_AUTOGEN_DIOPI_WRAPPER_SCRIPT}" "${DIPU_AUTOGEN_DIOPI_WRAPPER_CONFIG}"
+    )
+add_custom_target(autogen_diopi_kernels_cpp DEPENDS ${DIPU_AUTOGENED_KERNELS_CPP})
+add_dependencies(${DIPU_AUTOGENED_KERNELS} autogen_diopi_kernels_cpp)
 
 # --------build bind in python --------------
 file(GLOB BIND_SRC_FILES binding/Export*.cpp
@@ -98,3 +124,30 @@ add_library(${DIPU_PYTHON_LIB} SHARED ${BIND_SRC_FILES})
 # so temporarily use this target level setting. enhance in future. todo
 set_target_properties(${DIPU_PYTHON_LIB} PROPERTIES CXX_VISIBILITY_PRESET hidden)
 target_link_libraries(${DIPU_PYTHON_LIB} ${DIPU_LIB})
+
+# -------- build _C.python extention --------
+execute_process(COMMAND  sh -c "uname -m" OUTPUT_VARIABLE DIPU_C_PYTHON_EXT_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+find_package(PythonInterp REQUIRED)
+
+set(DIPU_C_PYTHON_EXT_LIB "_C.cpython-${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}-${DIPU_C_PYTHON_EXT_ARCH}-linux-gnu")
+file(GLOB DIPU_C_PYTHON_EXT_SRC_FILES stub.cpp
+)
+set(DIPU_C_PYTHON_EXT_FILES
+    ${DIPU_C_PYTHON_EXT_SRC_FILES}
+)
+message(STATUS "dipu c python extention building " ${DIPU_C_PYTHON_EXT_FILES})
+add_library(${DIPU_C_PYTHON_EXT_LIB} SHARED ${DIPU_C_PYTHON_EXT_FILES})
+set_target_properties(${DIPU_C_PYTHON_EXT_LIB} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/torch_dipu )
+target_link_libraries(${DIPU_C_PYTHON_EXT_LIB} ${DIPU_LIB})
+target_link_libraries(${DIPU_C_PYTHON_EXT_LIB} ${DIPU_PYTHON_LIB})
+target_link_libraries(${DIPU_C_PYTHON_EXT_LIB} "c10")
+target_link_libraries(${DIPU_C_PYTHON_EXT_LIB} "torch")
+target_link_libraries(${DIPU_C_PYTHON_EXT_LIB} "torch_cpu")
+target_link_libraries(${DIPU_C_PYTHON_EXT_LIB} "torch_python")
+target_compile_options(${DIPU_C_PYTHON_EXT_LIB} PRIVATE -fstack-protector-all)
+set_target_properties(${DIPU_C_PYTHON_EXT_LIB} PROPERTIES PREFIX "")
+
+
+# --------- install DIOPI impl libs --------------------
+file(COPY ${DIOPI_IMPL_LIB} DESTINATION ${PROJECT_SOURCE_DIR}/torch_dipu)
+message(STATUS "CMake install direcotry:   " ${PROJECT_SOURCE_DIR}/torch_dipu)


### PR DESCRIPTION
This PR is targeted to make all DIPU related build job in CMake, which includes
1. Autogen Kernels in CMake now.
2. Build _C.cpython extension in CMake.
3. The "mv *.so -> somewhere/*.so" is now also moved inside CMakelists.txt 