### PR TITLE
fix no need fallback function register

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -42,7 +42,6 @@ namespace at {
             DIPU_REGISTER_LOG("force fallback has been set, ");                                                         \
         }                                                                                                               \
         DIPU_REGISTER_LOG(opname << " will be fallback to cpu" << std::endl);                                           \
-        m.impl(opname, torch::CppFunction::makeFromBoxedFunction<&dipu_fallback>());                                    \
     }                                                                                                                   \
 } while (false);
 


### PR DESCRIPTION
There is a default low-priority fallback function, so there is no need to register a high-priority fallback.