### PR TITLE
rewrite the way of linking libdiopi_impl.so in CMake for DICP

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -83,7 +83,8 @@ target_link_libraries(${DIPU_LIB} ${DIPU_VENDOR_LIB})
 target_link_libraries(${DIPU_LIB} ${PROJECT_SOURCE_DIR}/third_party/kineto/libkineto/build/fmt/libfmt.a)
 target_link_libraries(${DIPU_LIB} ${PROJECT_SOURCE_DIR}/third_party/kineto/libkineto/build/libkineto.a)
 
-target_link_libraries(${DIPU_LIB} -Wl,--no-as-needed diopi_impl -Wl,--as-needed)
+# target_link_libraries(${DIPU_LIB} -Wl,--no-as-needed diopi_impl -Wl,--as-needed)
+target_link_libraries(${DIPU_LIB} diopi_impl)
 target_link_libraries(${DIPU_LIB} c10 torch torch_cpu)
 
 set(CMAKE_THREAD_PREFER_PTHREAD ON)


### PR DESCRIPTION
This PR is discussed with DICP team and the purpose is let DIPU compatible with DICP when building.
Please refer to the feishu doc "DICP接入DIPU"