### PR TITLE
Remove the function "init_state" from TopsGeneratorImpl.cpp

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/vendor/topsrider/TopsGeneratorImpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/topsrider/TopsGeneratorImpl.cpp
@@ -10,9 +10,6 @@ public:
   TopsGeneratorImpl(at::DeviceIndex device_index): dipu::DIPUGeneratorImpl(device_index) {
   }
 
-  void init_state() const override {
-  }
-
   void set_state(const c10::TensorImpl& state) override {
   }
 


### PR DESCRIPTION
Remove the function "init_state" from TopsGeneratorImpl.cpp because it has already been deleted in the parent class.