### PR TITLE
add DIPU_WITH_DIOPI_LIBRARY env option in dipu/setup.py

### DIFF
--- a/dipu/setup.py
+++ b/dipu/setup.py
@@ -39,6 +39,7 @@ def customized_cmake_args():
     cmake_device = "cuda"
     if(os.getenv("DIPU_DEVICE")):
         cmake_device = os.getenv("DIPU_DEVICE")
+    cmake_with_diopi_library = os.getenv("DIPU_WITH_DIOPI_LIBRARY", "INTERNAL")
     cmake_args.append("-DCMAKE_BUILD_TYPE=Release")
     cmake_args.append("-DDEVICE="+cmake_device)
     cmake_args.append("-DENABLE_COVERAGE=${USE_COVERAGE}")
@@ -46,7 +47,7 @@ def customized_cmake_args():
     cmake_args.append("-DDIPU_COMPILED_WITH_CXX11_ABI="+str(get_DIPU_COMPILED_WITH_CXX11_ABI()))
     cmake_args.append("-DDIOPI_CMAKE_PREFIX_PATH="+get_DIOPI_CMAKE_PREFIX_PATH())
     cmake_args.append("-DPYTORCH_DIR="+get_PYTORCH_DIR())
-    cmake_args.append("-DWITH_DIOPI=INTERNAL")
+    cmake_args.append("-DWITH_DIOPI_LIBRARY=" + cmake_with_diopi_library)
     return cmake_args
 
 def torch_dipu_headers():


### PR DESCRIPTION
在 dipu 的 setup.py 中增加了通过环境变量 `DIPU_WITH_DIOPI_LIBRARY` 修改 CMakeLists.txt 中的变量 `WITH_DIOPI_LIBRARY`。如此修改可以在燧原平台上编译无 diopi_impl 依赖的 torch_dipu ，以便后续 dicp 的 ci 搭建。